### PR TITLE
Rafactor common_events installation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ puppet_version = ENV['PUPPET_GEM_VERSION']
 facter_version = ENV['FACTER_GEM_VERSION']
 hiera_version = ENV['HIERA_GEM_VERSION']
 
-gem 'common_events_library', git: 'https://github.com/puppetlabs/puppetlabs-common_events.git', branch: "main"
 gems = {}
 
 gems['puppet'] = location_for(puppet_version)

--- a/Rakefile
+++ b/Rakefile
@@ -158,7 +158,7 @@ namespace :acceptance do
   desc 'Installs the module on the master'
   task :install_module do
     master.run_shell("rm -rf '/etc/puppetlabs/puppet/splunk_hec.yaml'")
-    Rake::Task['litmus:install_module'].invoke(master.uri)
+    # This litmus helper installs splunk_hec as well because it's symlinked into fixtures.
     Rake::Task['litmus:install_modules_from_directory'].invoke("#{Dir.pwd}/spec/fixtures/modules",'ssh_nodes')
     master.bolt_upload_file('./spec/support/acceptance/splunk_hec.yaml', '/etc/puppetlabs/puppet/splunk_hec.yaml')
   end

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,31 +1,13 @@
+$LOAD_PATH.unshift "#{Dir.pwd}/spec/fixtures/modules/common_events_library/lib"
+
 require 'spec_helper_acceptance'
 require 'common_events_library'
 require 'ostruct'
 
 describe 'Verify the minimum install' do
   describe 'with a basic test' do
-    # The following manifest first ensures pe-puppetserver is running, which is a requirement for this module.
-    cleanmanifest = <<-MANIFEST
-    # cloned from https://github.com/puppetlabs/puppetlabs-puppet_enterprise/blob/a82d3adafcf1dfd13f1c338032f325d80fa58eda/manifests/trapperkeeper/pe_service.pp#L10-L17
-    service { 'pe-puppetserver':
-      ensure     => running,
-      hasrestart => true,
-      restart    => "service pe-puppetserver reload",
-    }
-
-    class { 'splunk_hec':
-      url                    => 'http://localhost:8088/services/collector/event',
-      token                  => 'abcd1234',
-      record_event           => true,
-      pe_username            => 'admin',
-      pe_console             => 'localhost',
-      pe_password            => Sensitive('pie'),
-      include_api_collection => true,
-    }
-    MANIFEST
-
     it 'Sets up the pe-puppetserver service and splunk_hec class' do
-      apply_manifest(cleanmanifest, catch_failures: true)
+      apply_manifest(standard_manifest, catch_failures: true)
     end
 
     it 'Successfully creates a report after a simple puppet apply' do
@@ -80,43 +62,20 @@ describe 'Verify the minimum install' do
   end
 
   describe 'Collect events from PE and sends to the splunk endpoint' do
-    manifest = <<-MANIFEST
-      service { 'pe-puppetserver':
-        ensure     => running,
-        hasrestart => true,
-        restart    => "service pe-puppetserver reload",
-      }
-      class { 'splunk_hec':
-        url => "http://#{master.uri}:8088/services/collector/event",
-        pe_console => "#{master.uri}",
-        token => "abcd1234",
-        pe_username => "admin",
-        pe_password => Sensitive('pie'),
-        enable_reports => true,
-        manage_routes => true,
-        include_api_collection => true,
-      }
-      MANIFEST
-
-    it 'starts the api collection on the console' do
-      apply_manifest(manifest, catch_failures: true)
-    end
-
-    it 'posts jobs to PE console' do
+    before(:all) do
+      apply_manifest(standard_manifest, catch_failures: true)
       5.times do
         response = master.run_shell("puppet task run enterprise_tasks::test_connect -n #{master.uri}")
-        expect(response.exit_code).to eq(0)
+        raise 'task run failed' unless response.exit_code == 0
       end
+      # 'Waiting for the cron job to complete'
+      sleep(130)
     end
 
     it 'collects the api results and pushes correctly to splunk' do
-      puts 'Waiting for the cron job to complete'
-      sleep(130)
       # Get the total jobs
-      orchestrator = Orchestrator.new(master.uri.to_s, 'admin', 'pie', ssl_verify: false)
-      response = orchestrator.get_all_jobs
-      body = JSON.parse(response.body)
-      total_jobs = (body['pagination']['total'] || 0)
+      orchestrator = Orchestrator.new(master.uri.to_s, username: 'admin', password: 'pie', ssl_verify: false)
+      jobs = orchestrator.get_jobs(limit: 1)
 
       # Do a splunk search for the orchestrator sourcetype for the last 5 minutes
       cmd = 'docker exec splunk_enterprise_1 bash -c \'sudo /opt/splunk/bin/splunk search sourcetype="puppet:events_summary" -earliest_time -5m -latest_time now -auth admin:piepiepie\''
@@ -124,7 +83,7 @@ describe 'Verify the minimum install' do
       result = run_shell(cmd, expect_failures: true)
       events = result['stdout'].split("\n")
 
-      job_id = total_jobs - 4
+      job_id = jobs.total - 4
       expect(events.size).to equal(5)
       events.each do |event_str|
         event = JSON.parse(event_str)

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -57,3 +57,23 @@ end
 def return_host
   master.uri
 end
+
+def standard_manifest
+  <<-MANIFEST
+    service { 'pe-puppetserver':
+      ensure     => running,
+      hasrestart => true,
+      restart    => "service pe-puppetserver reload",
+    }
+    class { 'splunk_hec':
+      url                    => "http://#{master.uri}:8088/services/collector/event",
+      pe_console             => "#{master.uri}",
+      token                  => "abcd1234",
+      pe_username            => "admin",
+      pe_password            => Sensitive('pie'),
+      enable_reports         => true,
+      manage_routes          => true,
+      include_api_collection => true,
+    }
+  MANIFEST
+end


### PR DESCRIPTION
This should install all of the modules in `spec/fixtures/modules` into the Puppet Server, including `splunk_hec` and the `common_events` module. It knows to target the `ssh_nodes` group in the inventory as well so the order the tasks are invoked in doesn't matter.